### PR TITLE
Fix error logging

### DIFF
--- a/src/pages/embedded/index.ts
+++ b/src/pages/embedded/index.ts
@@ -981,15 +981,13 @@ window.onbeforeunload = function () {
 // Error handling
 window.addEventListener("error", (event) => {
 	event.preventDefault();
-	const {
-		// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-		error: { stack: errorLine }
-	} = event;
-	browserColorLog(formatError(event.error) + "\nAt: " + errorLine, "FgRed");
+	const errorLine = event.error?.stack || `${event.filename}:${event.lineno}:${event.colno}`;
+	const errorMessage = event.error ? formatError(event.error) : event.message || "Unknown error";
+	browserColorLog(errorMessage + "\nAt: " + errorLine, "FgRed");
 });
 
 window.addEventListener("unhandledrejection", (event) => {
 	event.preventDefault();
-	const errorLine = event.reason instanceof Error ? event?.reason?.stack : "Stack trace not available";
+	const errorLine = event.reason instanceof Error && event.reason?.stack ? event.reason.stack : "Stack trace not available";
 	browserColorLog(`Unhandled rejection: ${event.reason}\nAt: ${errorLine}`, "FgRed");
 });


### PR DESCRIPTION
This fixes:
```
Uncaught TypeError: Cannot read properties of null (reading 'stack')
```


When there is an error like this without a `stack` value:
```
ResizeObserver loop completed with undelivered notifications
```