### PR TITLE
Fix playlist management timeout warning

### DIFF
--- a/src/features/playlistManagementButtons/index.ts
+++ b/src/features/playlistManagementButtons/index.ts
@@ -50,7 +50,7 @@ export default createFeature({
 	},
 	onDisable: cleanupPlaylistManagementButtons,
 	onEnable: async ({ removeButton: { enabled: enable_playlist_remove_button }, resetButton: { enabled: enable_playlist_reset_button } }) => {
-		if (!(await waitForElement("ytd-playlist-video-list-renderer #sort-filter-menu:not(:empty)"))) {
+		if (!(await waitForElement("ytd-playlist-video-list-renderer #sort-filter-menu:not(:empty)", 2500, "optional"))) {
 			return;
 		}
 


### PR DESCRIPTION
This fixes:
```﻿
[waitForElement] Timeout after 2500ms — element not found: ytd-playlist-video-list-renderer #sort-filter-menu:not(:empty)
```

It's not clear why this is logged because the `waitForElement()` call is working.