### PR TITLE
fix(autoplay): disable autoplay reliably on slow player loads

### DIFF
--- a/src/features/automaticallyDisableAutoPlay/index.ts
+++ b/src/features/automaticallyDisableAutoPlay/index.ts
@@ -1,37 +1,88 @@
 import type { Nullable, YouTubePlayerDiv } from "@/src/types";
 
 import { createFeature } from "@/src/features/_registry/createFeature";
-import { waitForElement } from "@/src/utils/dom/wait";
+import { delay } from "@/src/utils/async";
+import { waitForElement, waitForPlayerLoaded } from "@/src/utils/dom/wait";
+import { isWatchPage } from "@/src/utils/url";
 
 import { metadata } from "./index.metadata";
+
+// The autoplay state before we first overrode it, so it can be restored if the
+// feature is switched off.
 let previousAutoPlayState: Nullable<boolean> = null;
+// Override YouTube's default autoplay only once per session; later videos keep
+// whatever the user chose.
+let hasOverriddenDefault = false;
+
+// Click the toggle until autoplay reaches `desired`, returning whether it got
+// there. The control can be present in the DOM before YouTube wires up its click
+// handler, so a single click is unreliable. Retry, re-querying the live element,
+// until aria-checked actually changes.
+async function clickToggleUntil(player: ParentNode, desired: boolean): Promise<boolean> {
+	for (let attempt = 0; attempt < 24 && readAutoPlayState(player) !== desired; attempt++) {
+		player.querySelector<HTMLButtonElement>(".ytp-autonav-toggle")?.click();
+		await delay(300);
+	}
+	return readAutoPlayState(player) === desired;
+}
+
+// Resolve the player once it is ready enough to trust the autoplay toggle.
+// waitForPlayerLoaded clears the initial unstarted/buffering load (where the
+// toggle can read a premature "false"), then we wait for the toggle itself,
+// which YouTube only adds a few seconds into playback. The settle loop in
+// onEnable absorbs any aria-checked lag that remains.
+async function getReadyPlayer(): Promise<Nullable<YouTubePlayerDiv>> {
+	const player = await waitForElement<YouTubePlayerDiv>("div#movie_player");
+	if (!player) return null;
+	try {
+		await waitForPlayerLoaded(player, 20000);
+	} catch {
+		return null;
+	}
+	const toggle = await waitForElement(".ytp-autonav-toggle-button", player, 15000);
+	return toggle ? player : null;
+}
+
+// Read the live autoplay state, re-querying so we never read a detached node.
+function readAutoPlayState(player: ParentNode): Nullable<boolean> {
+	const toggle = player.querySelector(".ytp-autonav-toggle-button");
+	return toggle ? toggle.getAttribute("aria-checked") === "true" : null;
+}
 
 export default createFeature({
 	...metadata,
+	onConfigChange: (config) => {
+		// Switching the feature off should let it override again when re-enabled,
+		// including when that happens off a watch page where onDisable never runs.
+		if (!config.enabled) hasOverriddenDefault = false;
+	},
 	onDisable: async () => {
-		const playerContainer = await waitForElement<YouTubePlayerDiv>("div#movie_player", 1000);
-		if (!playerContainer) return;
-		const autoPlayButtonElem = await waitForElement<HTMLButtonElement>(".ytp-autonav-toggle", playerContainer, 1000);
-		if (!autoPlayButtonElem) return;
-		const autoPlayButtonElemChecked = autoPlayButtonElem.querySelector(".ytp-autonav-toggle-button");
-		if (!autoPlayButtonElemChecked) return;
-		if (previousAutoPlayState === null) return;
-		const current = autoPlayButtonElemChecked.getAttribute("aria-checked") === "true";
-		if (current !== previousAutoPlayState) {
-			autoPlayButtonElem.click();
-		}
+		// Restore only when the feature is switched off while on a watch page, not
+		// when navigating away, which would otherwise wrongly re-enable autoplay.
+		if (!isWatchPage() || previousAutoPlayState === null) return;
+		const player = await getReadyPlayer();
+		if (!player) return;
+		await clickToggleUntil(player, previousAutoPlayState);
+		previousAutoPlayState = null;
+		hasOverriddenDefault = false;
 	},
 	onEnable: async () => {
-		const playerContainer = await waitForElement<YouTubePlayerDiv>("div#movie_player", 1000);
-		if (!playerContainer) return;
-		const autoPlayButtonElem = await waitForElement<HTMLButtonElement>(".ytp-autonav-toggle", playerContainer, 1000);
-		if (!autoPlayButtonElem) return;
-		const autoPlayButtonElemChecked = autoPlayButtonElem.querySelector(".ytp-autonav-toggle-button");
-		if (!autoPlayButtonElemChecked) return;
-		const current = autoPlayButtonElemChecked.getAttribute("aria-checked") === "true";
-		previousAutoPlayState = current;
-		if (current) {
-			autoPlayButtonElem.click();
+		if (hasOverriddenDefault) return;
+		const player = await getReadyPlayer();
+		if (!player) return;
+		// aria-checked can briefly read a premature "false" just after playback
+		// starts; allow a short window for it to settle before trusting it.
+		let current = readAutoPlayState(player);
+		for (let attempt = 0; attempt < 10 && current === false; attempt++) {
+			await delay(200);
+			current = readAutoPlayState(player);
 		}
+		if (current === null) return;
+		previousAutoPlayState ??= current;
+		// If the click never lands (e.g. a YouTube re-render rebinds the control),
+		// leave the session unmarked so the next video tries again instead of
+		// silently giving up.
+		if (current && !(await clickToggleUntil(player, false))) return;
+		hasOverriddenDefault = true;
 	}
 });


### PR DESCRIPTION
Recently, automatically disabling autoplay would randomly fail, leaving the toggle on. I have been observing this with 1.33.0 in LibreWolf 152.0.1 and reproduced the issue in both Firefox 152.0.2 and Chrome 149.0.7827.156.

This seems to be consistently tied to the player taking too long to load, whether that's caused by a slow network or the initial page hitch when navigating over to the first video. With cache disabled and a simulated slow network (4G/fast), autoplay would incorrectly stay enabled most of the time.

Also, because of how the detection was made, failing to disable autoplay on the first video would keep it enabled for the rest of the session, incorrectly assuming it has previously been disabled. During the initial load, the toggle would sometimes report a premature `false` (though, I wasn't able to consistently reproduce this), so the feature assumed autoplay was already off and did nothing. It also seems that the toggle might initially appear in the DOM before its handler was attached. For that reason, we wait for playback to start, let the premature `false` settle, and make sure autoplay has been successfully disabled by looking at `aria-checked`'s value.

The fix retains the ability to override the toggle's state for a given session and now properly reacts to `onConfigChange`.