### PR TITLE
Fix ESLint auto-fix on save

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,7 +2,7 @@
 	"js/ts.tsdk.path": "node_modules/typescript/lib",
 	"i18n-ally.localesPaths": ["public/locales"],
 	"editor.codeActionsOnSave": {
-		"source.fixAll": "always"
+		"source.fixAll.eslint": "always"
 	},
 	"eslint.codeActionsOnSave.mode": "all",
 	"editor.snippets.codeActions.enabled": true,


### PR DESCRIPTION
This fixes the following issue, where it appears something like Prettier is running in addition to ESLint:
<img width="1250" height="118" src="https://github.com/user-attachments/assets/737ab7c1-373b-4897-84b9-a9fd1cf43b67" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated editor save behavior to run ESLint-specific fixes on save, helping keep code style and lint issues cleaner automatically.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->