### PR TITLE
fix(settings): merge defaults into stored settings to fix options pag…

### DIFF
--- a/src/components/Settings/Settings.tsx
+++ b/src/components/Settings/Settings.tsx
@@ -22,7 +22,7 @@ import SettingsGenerator from "@/src/components/Settings/SettingsGenerator";
 import { type i18nInstanceType, i18nService } from "@/src/i18n";
 import { localeDirection } from "@/src/i18n/constants";
 import { getDefaultConfiguration } from "@/src/utils/config/defaults";
-import { parseStoredValue, updateConfigAtPath } from "@/src/utils/config/utils";
+import { deepMerge, parseStoredValue, updateConfigAtPath } from "@/src/utils/config/utils";
 import { getPathValue } from "@/src/utils/misc";
 
 import Loader from "../Loader";
@@ -53,8 +53,8 @@ export function getSettings(): Promise<configuration> {
 				const storedSettings: Partial<configuration> = Object.keys(settings)
 					.filter((key) => typeof key === "string" && Object.keys(defaultConfiguration).includes(key))
 					.reduce((acc, key) => Object.assign(acc, { [key]: parseStoredValue(settings[key] as string) }), {});
-				const castedSettings = storedSettings as configuration;
-				return resolve(castedSettings);
+				const mergedSettings = deepMerge(defaultConfiguration, storedSettings) as configuration;
+				return resolve(mergedSettings);
 			} catch (error) {
 				if (error instanceof Error) {
 					return reject(error);

--- a/src/defaults.ts
+++ b/src/defaults.ts
@@ -52,3 +52,7 @@ function setPartialSetting<K extends keyof configuration>(obj: Partial<configura
 function setSetting<K extends keyof configuration>(obj: configuration, key: K, value: configuration[K]) {
 	obj[key] = value;
 }
+
+void (async () => {
+	await setDefaultValues();
+})().catch((err) => console.error("[defaults] Failed to set default values:", err));

--- a/src/pages/content/index.ts
+++ b/src/pages/content/index.ts
@@ -17,7 +17,7 @@ import {
 } from "@/src/types";
 import { getDefaultConfiguration } from "@/src/utils/config/defaults";
 import { DEV_MODE } from "@/src/utils/config/env";
-import { parseStoredValue } from "@/src/utils/config/utils";
+import { deepMerge, parseStoredValue } from "@/src/utils/config/utils";
 import { sendExtensionMessage, sendExtensionOnlyMessage } from "@/src/utils/messaging";
 import { setupContentScriptBridge } from "@/src/utils/messaging/devtools";
 
@@ -75,7 +75,7 @@ const getStoredSettings = async (): Promise<configuration> => {
 			const storedSettings = Object.keys(settings)
 				.filter((key) => Object.keys(defaultConfiguration).includes(key))
 				.reduce((acc, key) => Object.assign(acc, { [key]: parseStoredValue(settings[key] as string) }), {}) as configuration;
-			return resolve(storedSettings);
+			return resolve(deepMerge(defaultConfiguration, storedSettings) as configuration);
 		});
 	});
 	return options;


### PR DESCRIPTION
…e crash (#1370)

Deep-merge the default configuration into stored settings when loading them on the options page and in the content script, and restore the defaults merge on background load removed in 82047c6f. Newly added nested settings (e.g. videosPerRow.videosPerRow) are now always populated, preventing the NumberInput 'Cannot read properties of undefined' crash that stopped the options page from opening.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved settings loading to preserve default values when stored settings are incomplete.
  * Ensured settings are initialized with defaults when the application starts.
  * Added error logging for failures during default settings initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->