### PR TITLE
feat(saveToWatchLaterButton): rebuild on YouTube's native components, add watch-page placements

### DIFF
--- a/public/locales/ca-ES.json
+++ b/public/locales/ca-ES.json
@@ -134,6 +134,7 @@
 						"failedToRemoveVideo": "Failed to remove video from Watch Later",
 						"failedToSaveVideo": "Failed to save video to Watch Later",
 						"removeVideo": "Remove from Watch Later",
+						"removedVideo": "Removed from Watch Later",
 						"saveVideo": "Save to Watch Later",
 						"unavailable": "Save to Watch Later button is unavailable due to a YouTube change"
 					}

--- a/public/locales/cs-CZ.json
+++ b/public/locales/cs-CZ.json
@@ -134,6 +134,7 @@
 						"failedToRemoveVideo": "Failed to remove video from Watch Later",
 						"failedToSaveVideo": "Nepodařilo se uložit video do hodinek později",
 						"removeVideo": "Remove from Watch Later",
+						"removedVideo": "Removed from Watch Later",
 						"saveVideo": "Uložit do sledování později",
 						"unavailable": "Save to Watch Later button is unavailable due to a YouTube change"
 					}

--- a/public/locales/de-DE.json
+++ b/public/locales/de-DE.json
@@ -134,6 +134,7 @@
 						"failedToRemoveVideo": "Failed to remove video from Watch Later",
 						"failedToSaveVideo": "Fehler beim Speichern des Videos in Später ansehen",
 						"removeVideo": "Remove from Watch Later",
+						"removedVideo": "Removed from Watch Later",
 						"saveVideo": "Später speichern",
 						"unavailable": "Save to Watch Later button is unavailable due to a YouTube change"
 					}

--- a/public/locales/en-GB.json
+++ b/public/locales/en-GB.json
@@ -134,6 +134,7 @@
 						"failedToRemoveVideo": "Failed to remove video from Watch Later",
 						"failedToSaveVideo": "Failed to save video to Watch Later",
 						"removeVideo": "Remove from Watch Later",
+						"removedVideo": "Removed from Watch Later",
 						"saveVideo": "Save to Watch Later",
 						"unavailable": "Save to Watch Later button is unavailable due to a YouTube change"
 					}

--- a/public/locales/en-US.json
+++ b/public/locales/en-US.json
@@ -134,6 +134,7 @@
 						"failedToRemoveVideo": "Failed to remove video from Watch Later",
 						"failedToSaveVideo": "Failed to save video to Watch Later",
 						"removeVideo": "Remove from Watch Later",
+						"removedVideo": "Removed from Watch Later",
 						"saveVideo": "Save to Watch Later",
 						"unavailable": "Save to Watch Later button is unavailable due to a YouTube change"
 					}

--- a/public/locales/en-US.json.d.ts
+++ b/public/locales/en-US.json.d.ts
@@ -67,6 +67,7 @@ interface EnUS {
 					extras: {
 						failedToRemoveVideo: "Failed to remove video from Watch Later";
 						failedToSaveVideo: "Failed to save video to Watch Later";
+						removedVideo: "Removed from Watch Later";
 						removeVideo: "Remove from Watch Later";
 						saveVideo: "Save to Watch Later";
 						unavailable: "Save to Watch Later button is unavailable due to a YouTube change";

--- a/public/locales/es-ES.json
+++ b/public/locales/es-ES.json
@@ -134,6 +134,7 @@
 						"failedToRemoveVideo": "Failed to remove video from Watch Later",
 						"failedToSaveVideo": "No se pudo guardar el vídeo para ver más tarde",
 						"removeVideo": "Remove from Watch Later",
+						"removedVideo": "Removed from Watch Later",
 						"saveVideo": "Guardar para ver más tarde",
 						"unavailable": "Save to Watch Later button is unavailable due to a YouTube change"
 					}

--- a/public/locales/fa-IR.json
+++ b/public/locales/fa-IR.json
@@ -134,6 +134,7 @@
 						"failedToRemoveVideo": "Failed to remove video from Watch Later",
 						"failedToSaveVideo": "Failed to save video to Watch Later",
 						"removeVideo": "Remove from Watch Later",
+						"removedVideo": "Removed from Watch Later",
 						"saveVideo": "Save to Watch Later",
 						"unavailable": "Save to Watch Later button is unavailable due to a YouTube change"
 					}

--- a/public/locales/fr-FR.json
+++ b/public/locales/fr-FR.json
@@ -134,6 +134,7 @@
 						"failedToRemoveVideo": "Failed to remove video from Watch Later",
 						"failedToSaveVideo": "Échec de l'enregistrement dans À regarder plus tard",
 						"removeVideo": "Remove from Watch Later",
+						"removedVideo": "Removed from Watch Later",
 						"saveVideo": "Enregistrer dans À regarder plus tard",
 						"unavailable": "Save to Watch Later button is unavailable due to a YouTube change"
 					}

--- a/public/locales/he-IL.json
+++ b/public/locales/he-IL.json
@@ -134,6 +134,7 @@
 						"failedToRemoveVideo": "Failed to remove video from Watch Later",
 						"failedToSaveVideo": "Failed to save video to Watch Later",
 						"removeVideo": "Remove from Watch Later",
+						"removedVideo": "Removed from Watch Later",
 						"saveVideo": "Save to Watch Later",
 						"unavailable": "Save to Watch Later button is unavailable due to a YouTube change"
 					}

--- a/public/locales/hi-IN.json
+++ b/public/locales/hi-IN.json
@@ -134,6 +134,7 @@
 						"failedToRemoveVideo": "Failed to remove video from Watch Later",
 						"failedToSaveVideo": "Failed to save video to Watch Later",
 						"removeVideo": "Remove from Watch Later",
+						"removedVideo": "Removed from Watch Later",
 						"saveVideo": "Save to Watch Later",
 						"unavailable": "Save to Watch Later button is unavailable due to a YouTube change"
 					}

--- a/public/locales/it-IT.json
+++ b/public/locales/it-IT.json
@@ -134,6 +134,7 @@
 						"failedToRemoveVideo": "Failed to remove video from Watch Later",
 						"failedToSaveVideo": "Impossibile salvare il video in Guarda più tardi",
 						"removeVideo": "Remove from Watch Later",
+						"removedVideo": "Removed from Watch Later",
 						"saveVideo": "Salva per guardare più tardi",
 						"unavailable": "Save to Watch Later button is unavailable due to a YouTube change"
 					}

--- a/public/locales/ja-JP.json
+++ b/public/locales/ja-JP.json
@@ -134,6 +134,7 @@
 						"failedToRemoveVideo": "Failed to remove video from Watch Later",
 						"failedToSaveVideo": "後で見ることに失敗しました",
 						"removeVideo": "Remove from Watch Later",
+						"removedVideo": "Removed from Watch Later",
 						"saveVideo": "後でウォッチに保存",
 						"unavailable": "Save to Watch Later button is unavailable due to a YouTube change"
 					}

--- a/public/locales/ko-KR.json
+++ b/public/locales/ko-KR.json
@@ -134,6 +134,7 @@
 						"failedToRemoveVideo": "Failed to remove video from Watch Later",
 						"failedToSaveVideo": "Failed to save video to Watch Later",
 						"removeVideo": "Remove from Watch Later",
+						"removedVideo": "Removed from Watch Later",
 						"saveVideo": "Save to Watch Later",
 						"unavailable": "Save to Watch Later button is unavailable due to a YouTube change"
 					}

--- a/public/locales/nl-NL.json
+++ b/public/locales/nl-NL.json
@@ -134,6 +134,7 @@
 						"failedToRemoveVideo": "Failed to remove video from Watch Later",
 						"failedToSaveVideo": "Opslaan van video om later te bekijken mislukt",
 						"removeVideo": "Remove from Watch Later",
+						"removedVideo": "Removed from Watch Later",
 						"saveVideo": "Opslaan in Later bekijken",
 						"unavailable": "Save to Watch Later button is unavailable due to a YouTube change"
 					}

--- a/public/locales/pl-PL.json
+++ b/public/locales/pl-PL.json
@@ -134,6 +134,7 @@
 						"failedToRemoveVideo": "Failed to remove video from Watch Later",
 						"failedToSaveVideo": "Nie udało się zapisać filmu do obejrzenia później",
 						"removeVideo": "Remove from Watch Later",
+						"removedVideo": "Removed from Watch Later",
 						"saveVideo": "Zapisz aby obejrzeć później",
 						"unavailable": "Save to Watch Later button is unavailable due to a YouTube change"
 					}

--- a/public/locales/pt-BR.json
+++ b/public/locales/pt-BR.json
@@ -134,6 +134,7 @@
 						"failedToRemoveVideo": "Failed to remove video from Watch Later",
 						"failedToSaveVideo": "Falha ao salvar o vídeo em \"Assistir mais tarde\"",
 						"removeVideo": "Remove from Watch Later",
+						"removedVideo": "Removed from Watch Later",
 						"saveVideo": "Salvar em \"Assistir mais tarde\"",
 						"unavailable": "Save to Watch Later button is unavailable due to a YouTube change"
 					}

--- a/public/locales/ru-RU.json
+++ b/public/locales/ru-RU.json
@@ -134,6 +134,7 @@
 						"failedToRemoveVideo": "Failed to remove video from Watch Later",
 						"failedToSaveVideo": "Не удалось сохранить видео в Смотреть позже",
 						"removeVideo": "Remove from Watch Later",
+						"removedVideo": "Removed from Watch Later",
 						"saveVideo": "Сохранить в Смотреть позже",
 						"unavailable": "Save to Watch Later button is unavailable due to a YouTube change"
 					}

--- a/public/locales/sv-SE.json
+++ b/public/locales/sv-SE.json
@@ -134,6 +134,7 @@
 						"failedToRemoveVideo": "Failed to remove video from Watch Later",
 						"failedToSaveVideo": "Det gick inte att spara videon till titta på senare",
 						"removeVideo": "Remove from Watch Later",
+						"removedVideo": "Removed from Watch Later",
 						"saveVideo": "Spara till titta på senare",
 						"unavailable": "Save to Watch Later button is unavailable due to a YouTube change"
 					}

--- a/public/locales/tr-TR.json
+++ b/public/locales/tr-TR.json
@@ -134,6 +134,7 @@
 						"failedToRemoveVideo": "Failed to remove video from Watch Later",
 						"failedToSaveVideo": "Videoyu daha sonra izlemek üzere kaydetme işlemi başarısız oldu",
 						"removeVideo": "Remove from Watch Later",
+						"removedVideo": "Removed from Watch Later",
 						"saveVideo": "Daha sonra izlemek için kaydet",
 						"unavailable": "Save to Watch Later button is unavailable due to a YouTube change"
 					}

--- a/public/locales/uk-UA.json
+++ b/public/locales/uk-UA.json
@@ -134,6 +134,7 @@
 						"failedToRemoveVideo": "Failed to remove video from Watch Later",
 						"failedToSaveVideo": "Не вдалося зберегти відео для перегляду пізніше",
 						"removeVideo": "Remove from Watch Later",
+						"removedVideo": "Removed from Watch Later",
 						"saveVideo": "Зберегти до годинника пізніше",
 						"unavailable": "Save to Watch Later button is unavailable due to a YouTube change"
 					}

--- a/public/locales/vi-VN.json
+++ b/public/locales/vi-VN.json
@@ -134,6 +134,7 @@
 						"failedToRemoveVideo": "Failed to remove video from Watch Later",
 						"failedToSaveVideo": "Failed to save video to Watch Later",
 						"removeVideo": "Remove from Watch Later",
+						"removedVideo": "Removed from Watch Later",
 						"saveVideo": "Save to Watch Later",
 						"unavailable": "Save to Watch Later button is unavailable due to a YouTube change"
 					}

--- a/public/locales/zh-CN.json
+++ b/public/locales/zh-CN.json
@@ -134,6 +134,7 @@
 						"failedToRemoveVideo": "Failed to remove video from Watch Later",
 						"failedToSaveVideo": "将视频保存到稍后观看失败",
 						"removeVideo": "Remove from Watch Later",
+						"removedVideo": "Removed from Watch Later",
 						"saveVideo": "保存至稍后观看",
 						"unavailable": "Save to Watch Later button is unavailable due to a YouTube change"
 					}

--- a/public/locales/zh-TW.json
+++ b/public/locales/zh-TW.json
@@ -134,6 +134,7 @@
 						"failedToRemoveVideo": "Failed to remove video from Watch Later",
 						"failedToSaveVideo": "Failed to save video to Watch Later",
 						"removeVideo": "Remove from Watch Later",
+						"removedVideo": "Removed from Watch Later",
 						"saveVideo": "Save to Watch Later",
 						"unavailable": "Save to Watch Later button is unavailable due to a YouTube change"
 					}

--- a/src/features/saveToWatchLaterButton/buttons.ts
+++ b/src/features/saveToWatchLaterButton/buttons.ts
@@ -2,6 +2,7 @@
 
 import type { Nullable } from "@/src/types";
 
+import { buildToastCommand, dispatchNativeCommand } from "@/src/utils/dom/nativeCommands";
 import {
 	type ButtonViewModelVariant,
 	createNativeButton,
@@ -115,6 +116,14 @@ export function createRowButtonController(isCurrent: () => boolean) {
 					if (!isCurrent()) return;
 					rowSaved.set(videoId, !saved);
 					swapButton(!saved);
+					// YouTube's pipeline shows a toast for a save, but not for a removal.
+					if (saved) {
+						dispatchNativeCommand(
+							buildToastCommand(
+								window.i18nextInstance.t((translations) => translations.pages.content.features.saveToWatchLaterButton.extras.removedVideo)
+							)
+						);
+					}
 				},
 				removing: saved,
 				videoId

--- a/src/features/saveToWatchLaterButton/index.ts
+++ b/src/features/saveToWatchLaterButton/index.ts
@@ -3,7 +3,7 @@ import type { Nullable } from "@/src/types";
 import eventManager from "@/src/events/EventManager";
 import { createFeature } from "@/src/features/_registry/createFeature";
 import { buildToastCommand, dispatchNativeCommand } from "@/src/utils/dom/nativeCommands";
-import { isNativeButtonComponentAvailable, readLockupData, type YtButtonViewModelElement } from "@/src/utils/dom/nativeComponents";
+import { readLockupData, waitForNativeButtonComponent, type YtButtonViewModelElement } from "@/src/utils/dom/nativeComponents";
 import { waitForElement } from "@/src/utils/dom/wait";
 import { browserColorLog } from "@/src/utils/logging";
 import { getCurrentPageType, getCurrentVideoId } from "@/src/utils/url";
@@ -22,8 +22,11 @@ let setupGeneration = 0;
 let warnedUnavailable = false;
 
 async function setupSaveToWatchLaterButtons() {
-	if (!isNativeButtonComponentAvailable()) {
-		if (!warnedUnavailable) {
+	const generation = setupGeneration;
+	const isCurrent = () => generation === setupGeneration;
+
+	if (!(await waitForNativeButtonComponent())) {
+		if (!warnedUnavailable && isCurrent()) {
 			warnedUnavailable = true;
 			browserColorLog("yt-button-view-model is not registered. YouTube may have changed its components.", "warning");
 			dispatchNativeCommand(
@@ -32,9 +35,7 @@ async function setupSaveToWatchLaterButtons() {
 		}
 		return;
 	}
-
-	const generation = setupGeneration;
-	const isCurrent = () => generation === setupGeneration;
+	if (!isCurrent()) return;
 
 	const pageType = await getCurrentPageType();
 	if (!isCurrent()) return;

--- a/src/i18n/migrate-translation.ts
+++ b/src/i18n/migrate-translation.ts
@@ -563,7 +563,8 @@ export const OldTranslationSchema: TypeToZodSchema<OldTranslationStruct> = objec
 			}),
 			saveToWatchLaterButton: object({
 				failedToSaveVideo: string(),
-				saveVideo: string()
+				saveVideo: string(),
+				savingVideo: string()
 			}),
 			screenshotButton: object({
 				enable: object({

--- a/src/i18n/types.ts
+++ b/src/i18n/types.ts
@@ -660,6 +660,7 @@ export type OldTranslationStruct = {
 			saveToWatchLaterButton: {
 				failedToSaveVideo: string;
 				saveVideo: string;
+				savingVideo: string;
 			};
 			screenshotButton: {
 				enable: {

--- a/src/utils/dom/nativeComponents.ts
+++ b/src/utils/dom/nativeComponents.ts
@@ -115,6 +115,18 @@ export function setNativeButtonBusy(host: YtButtonViewModelElement, busy: boolea
 	host.buttonOverrides = busy ? { state: "BUTTON_VIEW_MODEL_STATE_DISABLED" } : {};
 }
 
+// Wait for YouTube to register the component. On a slow load, it can register after us.
+// Resolve false after the timeout, so the caller can degrade instead of waiting forever.
+export function waitForNativeButtonComponent(timeout = 10000): Promise<boolean> {
+	if (isNativeButtonComponentAvailable()) return Promise.resolve(true);
+	return Promise.race([
+		customElements.whenDefined("yt-button-view-model").then(() => true),
+		new Promise<boolean>((resolve) => {
+			window.setTimeout(() => resolve(false), timeout);
+		})
+	]);
+}
+
 const customIconClasses = new Map<string, string>();
 
 function ensureCustomIconClass(svg: string): string {


### PR DESCRIPTION
## What this PR does

Rebuilds the "Save to Watch Later" button so it is a real YouTube button instead of an imitation, and extends it to watch pages.

**Placements**
- Home / Subscriptions video cards (as before)
- Watch-page suggested sidebar cards (new)
- The video actions row, next to Share (new) — this one is a persistent **toggle**: it saves, shows the saved state, and removes again. It reflects whether the current video is already in Watch Later.

**How it works now**
- Buttons are real `yt-button-view-model` elements built from Innertube props. YouTube renders, themes, and animates them (ripple, focus ring, tooltip, icon by `iconName`), so they match the native buttons pixel for pixel in both themes and both watch layouts (`ytd-watch-flexy` and `ytd-watch-grid`).
- Saving dispatches a `playlistEditEndpoint` through YouTube's own command pipeline (`ytd-app.resolveCommand`), so YouTube handles the request, the auth, and its own "Saved"/"Removed" toasts. `youtubei.js` remains only as a lazy-loaded fallback, plus one read the pipeline cannot do (the Watch Later membership check, using the same endpoint as YouTube's save dialog).
- Clicks are handled by one delegated capture-phase listener (survives YouTube re-creating hosts), passes are idempotent and retried by a scoped, rAF-coalesced MutationObserver, and a teardown generation counter aborts stale async setups across SPA navigations.
- Mixes, playlists, and albums are filtered out. If YouTube's components are missing, the feature waits for them to register (they can arrive late on slow loads), warns once with a localized toast, and keeps retrying on every navigation.

**New shared modules** (feature-agnostic, reusable by future features)
- `src/utils/dom/nativeComponents.ts` — build native buttons, read visual variants from renderer data, custom monochrome icons via CSS mask
- `src/utils/dom/nativeCommands.ts` — build and dispatch Innertube commands, including native toasts
- `src/utils/youtube/` — one memoized Innertube client + `isVideoInPlaylist`
- `src/utils/misc`: `findInObjectTree`; `src/utils/url`: `getCurrentVideoId`

**i18n**: three new keys under `saveToWatchLaterButton.extras` (`removeVideo`, `failedToRemoveVideo`, `unavailable`), synced to all locales with English placeholders for Crowdin; removed the dead `savingVideo` key.

## Notes for review
- Dispatch through `resolveCommand` is accepted-not-completed; the optimistic UI mirrors YouTube's own save behavior (documented in code).
- The old `createActionButton` in `playlistManagementButtons` is untouched; the icon-scraping catalog it replaced was removed.
- Icon names (`WATCH_LATER`, `CHECK_CIRCLE_THICK`) are typed and were verified against the client bundle's icon table.

## Manual testing
Both themes, logged in: card buttons on Home/Subscriptions (mixes excluded), sidebar cards, actions-row toggle round-trip with native toasts, already-saved videos showing the saved state, SPA navigation back/forward with no duplicates or flashes, feature disable/enable cleanup, and both watch layouts (`ytd-watch-grid` verified via experiment flag).