### PR TITLE
feat: add Catppuccin Mocha preset

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -135,12 +135,16 @@ src/features/MyNewFeature/
 ### Step 1: Update Global Configuration
 
 - Open `src/types/index.ts`
-- Add your feature:
+- Add your feature to the `configuration` type:
 
 ```ts
-myNewFeature: {
-	enabled: boolean;
-}
+// #region Configuration types
+export type configuration = {
+	// ... other existing features ...
+	myNewFeature: {
+		enabled: boolean;
+	};
+};
 ```
 
 Why: Ensures the feature is globally recognized and configurable.
@@ -150,7 +154,7 @@ Why: Ensures the feature is globally recognized and configurable.
 ### Step 2: Define Metadata & Settings UI
 
 - Create `index.metadata.ts`
-- Use `createFeatureMetadata()`
+- Use `createFeatureMetadata()` to define your feature metadata, and export it as a named `metadata` const, the feature registry will discover features by that exact export name
 
 #### Requirements
 
@@ -186,35 +190,36 @@ export const metadata = createFeatureMetadata({
 		anotherSetting: z.number().min(1).max(100)
 	},
 	sectionTitle: (t) => t((tr) => tr.settings.sections.myNewFeature.title),
-  settings: [
- 		{
- 			section: "myNewFeature",
- 			type: "group",
- 			children: [
- 				{
- 					component: "checkbox",
- 					id: "enabled",
- 					label: (t) => t((tr) => tr.settings.sections.myNewFeature.enable.label),
- 					title: (t) => t((tr) => tr.settings.sections.myNewFeature.enable.title)
- 				},
- 				{
- 					component: "input",
- 					id: "someSetting",
- 					label: (t) => t((tr) => tr.settings.sections.myNewFeature.settings.someSetting.label),
- 					title: (t) => t((tr) => tr.settings.sections.myNewFeature.settings.someSetting.title)
- 				},
- 				{
- 					component: "number",
- 					id: "anotherSetting",
- 					label: (t) => t((tr) => tr.settings.sections.myNewFeature.settings.anotherSetting.label),
- 					title: (t) => t((tr) => tr.settings.sections.myNewFeature.settings.anotherSetting.title),
- 					min: 1,
- 					max: 100,
- 					step: 1
- 				}
- 			]
- 		}
- 	]
+	settings: [
+		{
+			section: "myNewFeature",
+			type: "group",
+			children: [
+				{
+					component: "checkbox",
+					id: "enabled",
+					label: (t) => t((tr) => tr.settings.sections.myNewFeature.enable.label),
+					title: (t) => t((tr) => tr.settings.sections.myNewFeature.enable.title)
+				},
+				{
+					component: "input",
+					id: "someSetting",
+					label: (t) => t((tr) => tr.settings.sections.myNewFeature.settings.someSetting.label),
+					title: (t) => t((tr) => tr.settings.sections.myNewFeature.settings.someSetting.title)
+				},
+				{
+					component: "number",
+					id: "anotherSetting",
+					label: (t) => t((tr) => tr.settings.sections.myNewFeature.settings.anotherSetting.label),
+					title: (t) => t((tr) => tr.settings.sections.myNewFeature.settings.anotherSetting.title),
+					min: 1,
+					max: 100,
+					step: 1
+				}
+			]
+		}
+	]
+});
 ```
 
 📌 Add translations in:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,7 +56,7 @@ PRs opened against `main` will be asked to retarget `dev`.
 1. Check out `dev` and branch from it: `git checkout dev && git checkout -b feature/your-feature-name`
 2. Install dependencies: `npm install`
 3. Start dev server: `npm run dev`
-4. Create a feature in `src/features/MyNewFeature/`:
+4. Create a feature in `src/features/myNewFeature/`:
    - `index.metadata.ts` → schema + settings UI + i18n
    - `index.ts` → lifecycle + logic
 
@@ -116,7 +116,7 @@ Every feature must follow this contract to ensure consistency and stability.
 ### 1. Directory Structure
 
 ```
-src/features/MyNewFeature/
+src/features/myNewFeature/
 ```
 
 ---
@@ -142,7 +142,9 @@ src/features/MyNewFeature/
 export type configuration = {
 	// ... other existing features ...
 	myNewFeature: {
+		anotherSetting: number;
 		enabled: boolean;
+		someSetting: string;
 	};
 };
 ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -154,14 +154,14 @@ Why: Ensures the feature is globally recognized and configurable.
 ### Step 2: Define Metadata & Settings UI
 
 - Create `index.metadata.ts`
-- Use `createFeatureMetadata()` to define your feature metadata, and export it as a named `metadata` const, the feature registry will discover features by that exact export name
+- Use `createFeatureMetadata()` to define your feature metadata, and export it as a named `metadata` const. The feature registry discovers features by that exact export name.
 
 #### Requirements
 
-- `defaults` must include `enabled: false`
+- `config` describes every setting as a `field(schema, defaultValue)` — the registry derives defaults and validation from it
+- `config` must include an `enabled` field with a default of `false`
 - `id` must match the feature folder name
-- `schemaInput` must validate all settings
-- `settings` defines UI (required)
+- `settings` defines UI (required); setting ids are prefixed with the feature id (e.g. `myNewFeature.enabled`)
 
 #### i18n (Required)
 
@@ -175,48 +175,45 @@ Why: Prevents hardcoded UI and enables localization.
 
 ```ts
 import { z } from "zod/v4-mini";
+
 import { createFeatureMetadata } from "@/src/features/_registry/createFeatureMetadata";
+import { field } from "@/src/features/_registry/defineConfig";
 
 export const metadata = createFeatureMetadata({
-	defaults: {
-		enabled: false,
-		someSetting: "defaultValue",
-		anotherSetting: 5
+	config: {
+		enabled: field(z.boolean(), false),
+		someSetting: field(z.string(), "defaultValue"),
+		anotherSetting: field(z.number(), 5)
 	},
 	id: "myNewFeature",
-	schemaInput: {
-		enabled: z.boolean(),
-		someSetting: z.string(),
-		anotherSetting: z.number().min(1).max(100)
-	},
 	sectionTitle: (t) => t((tr) => tr.settings.sections.myNewFeature.title),
 	settings: [
 		{
-			section: "myNewFeature",
-			type: "group",
 			children: [
 				{
 					component: "checkbox",
-					id: "enabled",
+					id: "myNewFeature.enabled",
 					label: (t) => t((tr) => tr.settings.sections.myNewFeature.enable.label),
 					title: (t) => t((tr) => tr.settings.sections.myNewFeature.enable.title)
 				},
 				{
 					component: "input",
-					id: "someSetting",
+					id: "myNewFeature.someSetting",
 					label: (t) => t((tr) => tr.settings.sections.myNewFeature.settings.someSetting.label),
 					title: (t) => t((tr) => tr.settings.sections.myNewFeature.settings.someSetting.title)
 				},
 				{
 					component: "number",
-					id: "anotherSetting",
+					id: "myNewFeature.anotherSetting",
 					label: (t) => t((tr) => tr.settings.sections.myNewFeature.settings.anotherSetting.label),
-					title: (t) => t((tr) => tr.settings.sections.myNewFeature.settings.anotherSetting.title),
-					min: 1,
 					max: 100,
-					step: 1
+					min: 1,
+					step: 1,
+					title: (t) => t((tr) => tr.settings.sections.myNewFeature.settings.anotherSetting.title)
 				}
-			]
+			],
+			section: "myNewFeature",
+			type: "group"
 		}
 	]
 });
@@ -270,7 +267,7 @@ export default createFeature({
 ## ⚠️ Common Mistakes
 
 - Missing i18n (hardcoded strings)
-- Forgetting `enabled: false` in defaults
+- Forgetting the `enabled` field (default `false`) in `config`
 - Missing cleanup in `onDisable`
 - Direct state mutation instead of `stateAPI`
 - Ignoring SPA navigation (`onNavigate`)

--- a/src/deepDarkPresets.ts
+++ b/src/deepDarkPresets.ts
@@ -12,6 +12,7 @@ export const deepDarkPreset = [
 	"Arc-Dark",
 	"Black-and-White",
 	"Breeze-Dark",
+	"Catppuccin-Mocha",
 	"Custom",
 	"Deep-Dark",
 	"Discord",
@@ -106,6 +107,16 @@ export const deepDarkPresets = {
 		--main-text: #eff0f1;
 		--dimmer-text: #bdc3c7;
 		--shadow: 0 1px 0.5px rgba(0, 0, 0, .13);
+	}`,
+	'Catppuccin-Mocha': `
+		:root {
+			--main-color: #cba6f7;               /*Mauve*/
+			--main-background: #1e1e2e;          /*Base*/
+			--second-background: #181825;        /*Mantle*/
+			--hover-background: #313244;         /*Surface 0*/
+			--main-text: #cdd6f4;                /*Text*/
+			--dimmer-text: #a6adc8;              /*Subtext 1*/
+			--shadow: 0 1px 0.5px rgba(0, 0, 0, .15);
 	}`,
 	"Deep-Dark": `
 	:root {


### PR DESCRIPTION
### Summary
Added the **Catppuccin Mocha** theme preset to the built-in deep dark themes list.

### Changes
* Added `Catppuccin-Mocha` to `deepDarkPreset` array.
* Defined `:root` CSS variables using official Catppuccin Mocha palette color values:
  * `--main-color`: `#cba6f7` (Mauve)
  * `--main-background`: `#1e1e2e` (Base)
  * `--second-background`: `#181825` (Mantle)
  * `--hover-background`: `#313244` (Surface 0)
  * `--main-text`: `#cdd6f4` (Text)
  * `--dimmer-text`: `#a6adc8` (Subtext 1)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the Catppuccin Mocha theme preset.
  * Expanded the available deep-dark theme options with matching color styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->