### PR TITLE
Fix video progress selector

### DIFF
--- a/src/features/playlistLength/utils.ts
+++ b/src/features/playlistLength/utils.ts
@@ -9,6 +9,7 @@ import { waitForAllElements } from "@/src/utils/dom/wait";
 import { formatDuration, timeStringToSeconds } from "@/src/utils/format/time";
 import { conditionalStyles } from "@/src/utils/style";
 import { isNewYouTubeVideoLayout, isWatchPage } from "@/src/utils/url";
+import { getWatchedPercentage } from "@/src/utils/video";
 export const getHeaderSelectors = () => {
 	const playlistSelectors = PLAYLIST_PAGE_HEADER_SELECTORS;
 	const playlist =
@@ -253,15 +254,4 @@ function getVideoProgress(videoElement: Element): number {
 	const duration = getVideoDurationInSeconds(videoElement);
 	const percent = getWatchedPercentage(videoElement);
 	return Math.floor((percent / 100) * duration);
-}
-
-function getWatchedPercentage(videoElement: Element): number {
-	const oldSelector = ".ytd-thumbnail-overlay-resume-playback-renderer,#progress";
-	const newSelector = ".ytThumbnailOverlayProgressBarHostWatchedProgressBarSegment";
-	let progressBar = videoElement.querySelector<HTMLElement>(oldSelector);
-	if (!progressBar) {
-		progressBar = videoElement.querySelector<HTMLElement>(newSelector);
-	}
-	if (!progressBar) return 0;
-	return parseFloat(progressBar.style.width) || 0;
 }

--- a/src/features/playlistManagementButtons/index.ts
+++ b/src/features/playlistManagementButtons/index.ts
@@ -9,6 +9,7 @@ import { createActionButton } from "@/src/features/playlistManagementButtons/Act
 import { removeFromPlaylist } from "@/src/features/playlistManagementButtons/utils";
 import { IsDarkMode } from "@/src/utils/dom/state";
 import { waitForElement } from "@/src/utils/dom/wait";
+import { getThumbnailOverlay, getWatchedPercentage } from "@/src/utils/video";
 
 import { getPlaylistId } from "../playlistLength/utils";
 import { metadata } from "./index.metadata";
@@ -21,7 +22,6 @@ interface YTDPlaylistVideoRenderer extends HTMLElement {
 	playlistVideoId: string;
 }
 const PLAYLIST_ITEM_SELECTOR = "ytd-playlist-video-list-renderer ytd-playlist-video-renderer";
-const THUMBNAIL_OVERLAY_SELECTOR = "#overlays ytd-thumbnail-overlay-resume-playback-renderer";
 const CHIP_BAR_VIEW_MODEL_HEADER_SELECTOR = "chip-bar-view-model";
 
 let playlistObserver: Nullable<MutationObserver> = null;
@@ -77,7 +77,7 @@ function setupPlaylistManagementButtons(config: configuration["playlistManagemen
 
 				const removeButton = item.querySelector(".yte-remove-button");
 				const resetButton = item.querySelector(".yte-reset-button");
-				const resumeOverlay = item.querySelector(THUMBNAIL_OVERLAY_SELECTOR);
+				const hasWatchProgress = getWatchedPercentage(item) > 0;
 
 				if (enable_playlist_remove_button && !removeButton) {
 					const removeButton = await createActionButton({
@@ -102,7 +102,7 @@ function setupPlaylistManagementButtons(config: configuration["playlistManagemen
 					menu.prepend(removeButton);
 				}
 
-				if (enable_playlist_reset_button && !resetButton && resumeOverlay) {
+				if (enable_playlist_reset_button && !resetButton && hasWatchProgress) {
 					const resetButton = await createActionButton({
 						className: "yte-reset-button yte-action-button-large",
 						featureName: "playlistManagementButtons",
@@ -112,7 +112,7 @@ function setupPlaylistManagementButtons(config: configuration["playlistManagemen
 							const { playlistVideoId: videoId } = item as YTDPlaylistVideoRenderer;
 							const history = await youtube.getHistory();
 							await history.removeVideo(videoId, 5);
-							item.querySelector(THUMBNAIL_OVERLAY_SELECTOR)?.remove();
+							getThumbnailOverlay(item)?.remove();
 							resetButton.remove();
 							await addRemoveAllButton();
 						},
@@ -147,8 +147,7 @@ function setupPlaylistManagementButtons(config: configuration["playlistManagemen
 				const timeStatus = item.querySelector("ytd-thumbnail-overlay-time-status-renderer");
 				if (!timeStatus) return;
 
-				const progressBar = item.querySelector<HTMLElement>("ytd-thumbnail #progress");
-				const progressWidth = progressBar ? parseFloat(progressBar.style.width) : 0;
+				const progressWidth = getWatchedPercentage(item);
 				if (progressWidth === 100) {
 					watchedCount++;
 				}
@@ -194,8 +193,7 @@ function setupPlaylistManagementButtons(config: configuration["playlistManagemen
 					const playlistItems = document.querySelectorAll(PLAYLIST_ITEM_SELECTOR);
 
 					for (const item of playlistItems) {
-						const progressBar = item.querySelector<HTMLElement>("ytd-thumbnail #progress");
-						const progressWidth = progressBar ? parseFloat(progressBar.style.width) : 0;
+						const progressWidth = getWatchedPercentage(item);
 						if (progressWidth === 100) {
 							const {
 								data: { setVideoId }

--- a/src/utils/video/index.ts
+++ b/src/utils/video/index.ts
@@ -1,0 +1,27 @@
+const THUMBNAIL_OVERLAY_SELECTORS = ["ytd-thumbnail-overlay-resume-playback-renderer", "ytw-thumbnail-overlay-resume-playback-renderer"] as const;
+
+const THUMBNAIL_PROGRESS_BAR_SELECTORS = [
+	".ytd-thumbnail-overlay-resume-playback-renderer #progress",
+	".ytThumbnailOverlayProgressBarHostWatchedProgressBarSegment",
+	".ytwThumbnailOverlayResumePlaybackRendererThumbnailOverlayResumePlaybackProgress"
+] as const;
+
+export function getThumbnailOverlay(videoElement: Element): Element | null {
+	for (const selector of THUMBNAIL_OVERLAY_SELECTORS) {
+		const overlay = videoElement.querySelector(selector);
+		if (overlay) {
+			return overlay;
+		}
+	}
+	return null;
+}
+
+export function getWatchedPercentage(videoElement: Element): number {
+	for (const selector of THUMBNAIL_PROGRESS_BAR_SELECTORS) {
+		const progressBar = videoElement.querySelector<HTMLElement>(selector);
+		if (progressBar) {
+			return parseFloat(progressBar.style.width) || 0;
+		}
+	}
+	return 0;
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved watch-progress detection across playlist controls.
  * Reset controls now appear consistently based on actual watched progress.
  * Resetting videos more reliably removes thumbnail overlays.
  * “Remove all watched” now accurately identifies and removes watched videos.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->